### PR TITLE
fix typo: getLatestArticle()

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -13,7 +13,7 @@ class NewsFeedReader extends Reader {
    *
    * @returns {Promise<Article | null>}
    */
-  async getLatestArtible () {
+  async getLatestArticle () {
     const articles = await this.getAllArticles()
     return articles?.[articles.length - 1]
   }

--- a/test/all.js
+++ b/test/all.js
@@ -59,7 +59,7 @@ test('immediate update', async (t) => {
   t.alike(await reader.getConfig(), config)
   t.alike(await reader.getIcon(), icon)
 
-  const latestArticle = await reader.getLatestArtible()
+  const latestArticle = await reader.getLatestArticle()
 
   t.alike(latestArticle, {
     title: 'Bar Article 2',

--- a/types/lib/reader.d.ts
+++ b/types/lib/reader.d.ts
@@ -9,7 +9,7 @@ declare class NewsFeedReader extends Reader {
      *
      * @returns {Promise<Article | null>}
      */
-    getLatestArtible(): Promise<Article | null>;
+    getLatestArticle(): Promise<Article | null>;
 }
 declare namespace NewsFeedReader {
     export { Article };


### PR DESCRIPTION
In the readME it says to use the getLatestArticle() function, but it currently doesn't exist because there is a typo and you need to use getLatestArtible()